### PR TITLE
[FEAT] 식당 순서 변경시에 홈스크린 페이지뷰 갱신

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -290,7 +290,9 @@ class _HomeScreenState extends State<HomeScreen> {
                                   SettingScreen(),
                         ),
                       );
-                      setState(() {});
+                      setState(() {
+                        getMealsByDate();
+                      });
                     },
                     icon: const Icon(Icons.settings),
                     color: NyamColors.customGrey,
@@ -427,7 +429,6 @@ class _HomeScreenState extends State<HomeScreen> {
                               : HomeScreen.ansungRestaurantName[index];
                       return MealsOfRestaurant(
                         restaurantName: restaurantName,
-                        index: index,
                         mealsForDay: snapshot.data!,
                       );
                     },
@@ -446,21 +447,10 @@ class MealsOfRestaurant extends StatefulWidget {
   MealsOfRestaurant({
     super.key,
     required this.mealsForDay,
-    required this.index,
     required this.restaurantName,
   });
 
-  int index;
   MealsForDay mealsForDay;
-  List<String> seoulRestaurantDetailNames = [
-    "경영경제관 310관 B4층",
-    "블루미르관 308관",
-    "블루미르관 309관",
-    "법학관 303관 B1층",
-    "법학관 303관 B1층",
-  ];
-
-  String ansungRestaurantDetailName = "707관";
 
   String restaurantName;
 
@@ -484,6 +474,7 @@ class _MealsOfRestaurantState extends State<MealsOfRestaurant> {
   MealsForDay dinner = [];
   bool isTodayMeals = true;
   bool isBurgerOrRamen = false;
+  String restaurantDetailName = "";
 
   void checkIsTodayMeals() {
     if (widget.mealsForDay.isNotEmpty) {
@@ -506,27 +497,35 @@ class _MealsOfRestaurantState extends State<MealsOfRestaurant> {
     switch (restaurantName) {
       case "참슬기":
         restaurantType = RestaurantType.chamsulgi;
+        restaurantDetailName = "경영경제관 310관 B4층";
         break;
       case "생활관A":
         restaurantType = RestaurantType.domitoryA;
+        restaurantDetailName = "블루미르관 308관";
         break;
       case "생활관B":
         restaurantType = RestaurantType.domitoryB;
+        restaurantDetailName = "블루미르관 309관";
         break;
       case "학생식당":
         restaurantType = RestaurantType.student;
+        restaurantDetailName = "법학관 303관 B1층";
         break;
       case "교직원":
         restaurantType = RestaurantType.staff;
+        restaurantDetailName = "법학관 303관 B1층";
         break;
       case "카우이츠":
         restaurantType = RestaurantType.cauEats;
+        restaurantDetailName = "707관";
         break;
       case "카우버거":
         restaurantType = RestaurantType.cauBurger;
+        restaurantDetailName = "707관";
         break;
       case "라면":
         restaurantType = RestaurantType.ramen;
+        restaurantDetailName = "707관";
         break;
       default:
         restaurantType = RestaurantType.chamsulgi;
@@ -568,9 +567,7 @@ class _MealsOfRestaurantState extends State<MealsOfRestaurant> {
                   left: 10,
                 ),
                 child: Text(
-                  HomeScreen.entryPoint == CampusType.seoul
-                      ? widget.seoulRestaurantDetailNames[widget.index]
-                      : widget.ansungRestaurantDetailName,
+                  restaurantDetailName,
                   style: const TextStyle(
                     color: NyamColors.grey50,
                     fontSize: 12,


### PR DESCRIPTION
## 🟠 관련 이슈
- close #11 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟠 구현/변경 사항 및 이유
Setting Screen 에 접근 뒤 HomeScreen 으로 돌아오는 과정에서 getMealsByDate 함수를 호출하여 변경된 식당 순서대로 PageView 를 리로드 하도록 하였습니다. 

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟠 PR Point
없습니다.
<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟠 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

