### PR TITLE
[FEAT] menu UI 의 분기처리를 합니다.

### DIFF
--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -89,6 +89,25 @@ class _SettingScreenState extends State<SettingScreen> {
     }
   }
 
+  initializeRestaurantPicker() {
+    if (widget.selectedCampus == CampusType.seoul) {
+      HomeScreen.isSelectedRestaurant = [
+        false,
+        false,
+        false,
+        false,
+        false,
+      ];
+    } else {
+      HomeScreen.isSelectedRestaurant = [
+        false,
+        false,
+        false,
+      ];
+    }
+    HomeScreen.isSelectedRestaurant[0] = true;
+  }
+
   @override
   void initState() {
     super.initState();
@@ -288,6 +307,7 @@ class _SettingScreenState extends State<SettingScreen> {
                                     : HomeScreen.ansungRestaurantName
                                         .insert(newIndex, item);
                                 updateRestaurantSorting();
+                                initializeRestaurantPicker();
                               },
                             );
                           },
@@ -302,7 +322,6 @@ class _SettingScreenState extends State<SettingScreen> {
                                     padding: const EdgeInsets.only(
                                       left: 11,
                                     ),
-                                    // color: Colors.white,
                                     child: Row(
                                       crossAxisAlignment:
                                           CrossAxisAlignment.start,

--- a/lib/widgets/menu_widget.dart
+++ b/lib/widgets/menu_widget.dart
@@ -93,6 +93,7 @@ class _MenuState extends State<Menu> {
       }
     } else {
       openStatus = OpenStatusType.notRunning;
+      isOpenedToSee = false;
     }
   }
 
@@ -286,7 +287,7 @@ class _MenuState extends State<Menu> {
               Padding(
                 padding: const EdgeInsets.only(
                   right: 20,
-                  bottom: 20,
+                  bottom: 10,
                 ),
                 child: MediaQuery.removePadding(
                   removeTop: true,

--- a/lib/widgets/menu_widget.dart
+++ b/lib/widgets/menu_widget.dart
@@ -342,6 +342,7 @@ class _MenuState extends State<Menu> {
                               ),
                             if (widget.restaurantName != "학생식당")
                               Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
                                   Text(
                                     widget.mealsForDay[0].restaurantType ==

--- a/lib/widgets/menu_widget.dart
+++ b/lib/widgets/menu_widget.dart
@@ -285,7 +285,8 @@ class _MenuState extends State<Menu> {
             if (isOpenedToSee)
               Padding(
                 padding: const EdgeInsets.only(
-                  right: 20.0,
+                  right: 20,
+                  bottom: 20,
                 ),
                 child: MediaQuery.removePadding(
                   removeTop: true,
@@ -314,47 +315,78 @@ class _MenuState extends State<Menu> {
                         child: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
-                            Text(
-                              widget.mealsForDay[0].restaurantType ==
-                                      RestaurantType.cauBurger
-                                  ? ""
-                                  : widget.mealsForDay[index].price,
-                              style: TextStyle(
-                                fontSize:
-                                    widget.mealsForDay[0].restaurantType ==
-                                            RestaurantType.cauBurger
-                                        ? 0
-                                        : 14,
-                                fontWeight: FontWeight.w500,
-                              ),
-                            ),
-                            Padding(
-                              padding: const EdgeInsets.only(
-                                top: 10,
-                                bottom: 10,
-                              ),
-                              child: GridView.builder(
-                                physics: const NeverScrollableScrollPhysics(),
-                                shrinkWrap: true,
-                                gridDelegate:
-                                    SliverGridDelegateWithFixedCrossAxisCount(
-                                  crossAxisCount: crossCount,
-                                  childAspectRatio: 5,
-                                ),
-                                itemCount: menu.length,
-                                itemBuilder: (context, index) {
-                                  return SizedBox(
-                                    child: Text(
-                                      menu[index],
+                            if (widget.restaurantName == "학생식당" &&
+                                menu.length == 1)
+                              Padding(
+                                padding: const EdgeInsets.only(bottom: 6),
+                                child: Row(
+                                  mainAxisAlignment:
+                                      MainAxisAlignment.spaceBetween,
+                                  children: [
+                                    Text(
+                                      menu[0],
                                       style: const TextStyle(
                                         fontSize: 14,
                                         fontWeight: FontWeight.w600,
                                       ),
                                     ),
-                                  );
-                                },
+                                    Text(
+                                      widget.mealsForDay[index].price,
+                                      style: const TextStyle(
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    ),
+                                  ],
+                                ),
                               ),
-                            ),
+                            if (widget.restaurantName != "학생식당")
+                              Column(
+                                children: [
+                                  Text(
+                                    widget.mealsForDay[0].restaurantType ==
+                                            RestaurantType.cauBurger
+                                        ? ""
+                                        : widget.mealsForDay[index].price,
+                                    style: TextStyle(
+                                      fontSize: widget.mealsForDay[0]
+                                                  .restaurantType ==
+                                              RestaurantType.cauBurger
+                                          ? 0
+                                          : 14,
+                                      fontWeight: FontWeight.w500,
+                                    ),
+                                  ),
+                                  Padding(
+                                    padding: const EdgeInsets.only(
+                                      top: 10,
+                                      bottom: 10,
+                                    ),
+                                    child: GridView.builder(
+                                      physics:
+                                          const NeverScrollableScrollPhysics(),
+                                      shrinkWrap: true,
+                                      gridDelegate:
+                                          SliverGridDelegateWithFixedCrossAxisCount(
+                                        crossAxisCount: crossCount,
+                                        childAspectRatio: 5,
+                                      ),
+                                      itemCount: menu.length,
+                                      itemBuilder: (context, index) {
+                                        return SizedBox(
+                                          child: Text(
+                                            menu[index],
+                                            style: const TextStyle(
+                                              fontSize: 14,
+                                              fontWeight: FontWeight.w600,
+                                            ),
+                                          ),
+                                        );
+                                      },
+                                    ),
+                                  ),
+                                ],
+                              )
                           ],
                         ),
                       );


### PR DESCRIPTION
## 🟠 관련 이슈
- close #13 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟠 구현/변경 사항 및 이유
학생식당의 메뉴가 단일 메뉴로 여러가지가 동시에 들어오는 경우의 분기를 처리해주었습니다. 
RestaurantName 이 일치하고 메뉴 길이가 1인 경우 디자인대로 메뉴, 가격을 한 로우로 나타도록 하였습니다. 

또한 SettingScreen 에서 식당 순서를 변경하고 Home Screen 으로 다시 나올 경우에 Restaurant Picker 를 초기화 해주도록 하였습니다. 
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟠 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟠 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
<img width="479" alt="image" src="https://user-images.githubusercontent.com/64766255/226095935-33fdab1a-9455-4a58-ad5f-f5224e2420d0.png">
