### PR TITLE
[CHORE] setting screen 하단 리스트의 터치 영역 수정

### DIFF
--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -444,21 +444,21 @@ class _SettingScreenState extends State<SettingScreen> {
               physics: const NeverScrollableScrollPhysics(),
               shrinkWrap: true,
               itemBuilder: (context, index) {
-                return Padding(
-                  padding: const EdgeInsets.only(
-                    left: 20,
-                    right: 16,
-                    top: 12,
-                    bottom: 12,
-                  ),
-                  child: GestureDetector(
-                    onTap: () {
-                      if (index == 0 || index == 1) {
-                        luanchURL(index);
-                      } else {
-                        sendEmail();
-                      }
-                    },
+                return GestureDetector(
+                  onTap: () {
+                    if (index == 0 || index == 1) {
+                      luanchURL(index);
+                    } else {
+                      sendEmail();
+                    }
+                  },
+                  child: Padding(
+                    padding: const EdgeInsets.only(
+                      left: 20,
+                      right: 16,
+                      top: 16,
+                      bottom: 16,
+                    ),
                     child: Row(
                       mainAxisAlignment: MainAxisAlignment.spaceBetween,
                       children: [


### PR DESCRIPTION
## 🟠 관련 이슈
- close #36 
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->

## 🟠 구현/변경 사항 및 이유
세팅 스크린의 하단 리스트가 터치가 잘 되지 않아 터치 영역을 수정하였습니다.
기존 문제는 패딩 값을 제외한 로우 위젯만 GestureDetector 가 감싸주고 있었는데 이를 상위로 빼주어 패딩까지 감싸 터치 제스처를 인식하도록 수정하였습니다. 또한 실기기에서 패딩 값이 작게 나와 좀 더 크게 변경하여 원활한 터치가 이루어지도록 변경하였습니다.

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->

## 🟠 PR Point

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->

## 🟠 참고 사항

<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->

