### PR TITLE
[FIX] 기본 캠퍼스 설정에 디폴트값을 서울로 변경하였습니다.

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -86,7 +86,7 @@ class _HomeScreenState extends State<HomeScreen> {
           HomeScreen.entryPoint = CampusType.ansung;
         }
       } else {
-        HomeScreen.preferences.setString('favoriteCampus', '');
+        HomeScreen.preferences.setString('favoriteCampus', '서울');
       }
 
       if (sortedSeoulRestaurants != null) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 1.0.0+2
+version: 1.0.0+3
 
 environment:
   sdk: '>=2.19.2 <3.0.0'


### PR DESCRIPTION
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
## 🟠 관련 이슈
- close #43 

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
## 🟠 구현/변경 사항 및 이유
이전 작업에서 기본 캠퍼스 설정에 대한 버그를 인지하여 수정하였으나 이게 올바르게 적용이 되지 않은 것을 발견하여 다시 수정합니다. 
User Default 값에서 기본 캠퍼스 값을 가져오는 과정에서 프로퍼티가 저장이 되어 있지 않다면 "" 값을 할당해주어 첫 설치시 기본 캠퍼스가 안성으로 되어 있었습니다. 이를 "서울" 로 할당하여 해결해주었습니다.

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
## 🟠 PR Point


<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
## 🟠 참고 사항

