### PR TITLE
[FIX] menu 의 touch area 를 수정합니다.

### DIFF
--- a/lib/widgets/menu_widget.dart
+++ b/lib/widgets/menu_widget.dart
@@ -232,166 +232,167 @@ class _MenuState extends State<Menu> {
 
   @override
   Widget build(BuildContext context) {
-    return Container(
-      decoration: BoxDecoration(
-        color: Colors.white,
-        borderRadius: BorderRadius.circular(20),
-      ),
-      child: Padding(
-        padding: const EdgeInsets.only(
-          left: 20,
+    return GestureDetector(
+      onTap: () {
+        setState(() {
+          if (openStatus != OpenStatusType.notRunning) {
+            isOpenedToSee = !isOpenedToSee;
+          }
+        });
+      },
+      child: Container(
+        decoration: BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.circular(20),
         ),
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Row(
-              mainAxisAlignment: MainAxisAlignment.spaceBetween,
-              children: [
-                Row(
-                  crossAxisAlignment: CrossAxisAlignment.center,
-                  children: [
-                    if (!isBurgerOrRamen) icon,
-                    Padding(
-                      padding: isBurgerOrRamen
-                          ? EdgeInsets.zero
-                          : const EdgeInsets.only(left: 10),
-                      child: mealsTitle,
-                    ),
-                    Padding(
-                      padding: const EdgeInsets.only(left: 10),
-                      child: OpenState(
-                        openTimeString: openTimeString,
-                        closeTimeString: closeTimeString,
-                        openStatusType: openStatus,
-                        mealsForDay: widget.mealsForDay,
+        child: Padding(
+          padding: const EdgeInsets.only(
+            left: 20,
+          ),
+          child: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Row(
+                mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                children: [
+                  Row(
+                    crossAxisAlignment: CrossAxisAlignment.center,
+                    children: [
+                      if (!isBurgerOrRamen) icon,
+                      Padding(
+                        padding: isBurgerOrRamen
+                            ? EdgeInsets.zero
+                            : const EdgeInsets.only(left: 10),
+                        child: mealsTitle,
                       ),
-                    ),
-                  ],
-                ),
-                IconButton(
-                    onPressed: () {
-                      setState(() {
-                        if (openStatus != OpenStatusType.notRunning) {
-                          isOpenedToSee = !isOpenedToSee;
-                        }
-                      });
-                    },
-                    icon: Icon(
-                      isOpenedToSee
-                          ? Icons.keyboard_arrow_up_rounded
-                          : Icons.keyboard_arrow_down_rounded,
-                    ))
-              ],
-            ),
-            if (isOpenedToSee)
-              Padding(
-                padding: const EdgeInsets.only(
-                  right: 20,
-                  bottom: 10,
-                ),
-                child: MediaQuery.removePadding(
-                  removeTop: true,
-                  context: context,
-                  child: ListView.separated(
-                    physics: const NeverScrollableScrollPhysics(),
-                    shrinkWrap: true,
-                    separatorBuilder: (context, index) => Divider(
-                      height: 0.5,
-                      color: NyamColors.customGrey.withOpacity(0.5),
-                    ),
-                    itemCount: widget.mealsForDay.length,
-                    itemBuilder: (context, index) {
-                      var crossCount = 2;
-                      var menu = widget.mealsForDay[index].menu;
-                      if (widget.restaurantName == "라면") {
-                        menu = menu.sublist(1);
-                      } else if (widget.restaurantName == "카우버거") {
-                        menu = ["햄버거 판매시간 ${menu[0].substring(6)}"];
-                        crossCount = 1;
-                      }
-                      return Padding(
-                        padding: const EdgeInsets.only(
-                          top: 10,
+                      Padding(
+                        padding: const EdgeInsets.only(left: 10),
+                        child: OpenState(
+                          openTimeString: openTimeString,
+                          closeTimeString: closeTimeString,
+                          openStatusType: openStatus,
+                          mealsForDay: widget.mealsForDay,
                         ),
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            if (widget.restaurantName == "학생식당" &&
-                                menu.length == 1)
-                              Padding(
-                                padding: const EdgeInsets.only(bottom: 6),
-                                child: Row(
-                                  mainAxisAlignment:
-                                      MainAxisAlignment.spaceBetween,
-                                  children: [
-                                    Text(
-                                      menu[0],
-                                      style: const TextStyle(
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.w600,
+                      ),
+                    ],
+                  ),
+                  Icon(
+                    isOpenedToSee
+                        ? Icons.keyboard_arrow_up_rounded
+                        : Icons.keyboard_arrow_down_rounded,
+                  )
+                ],
+              ),
+              if (isOpenedToSee)
+                Padding(
+                  padding: const EdgeInsets.only(
+                    right: 20,
+                    bottom: 10,
+                  ),
+                  child: MediaQuery.removePadding(
+                    removeTop: true,
+                    context: context,
+                    child: ListView.separated(
+                      physics: const NeverScrollableScrollPhysics(),
+                      shrinkWrap: true,
+                      separatorBuilder: (context, index) => Divider(
+                        height: 0.5,
+                        color: NyamColors.customGrey.withOpacity(0.5),
+                      ),
+                      itemCount: widget.mealsForDay.length,
+                      itemBuilder: (context, index) {
+                        var crossCount = 2;
+                        var menu = widget.mealsForDay[index].menu;
+                        if (widget.restaurantName == "라면") {
+                          menu = menu.sublist(1);
+                        } else if (widget.restaurantName == "카우버거") {
+                          menu = ["햄버거 판매시간 ${menu[0].substring(6)}"];
+                          crossCount = 1;
+                        }
+                        return Padding(
+                          padding: const EdgeInsets.only(
+                            top: 10,
+                          ),
+                          child: Column(
+                            crossAxisAlignment: CrossAxisAlignment.start,
+                            children: [
+                              if (widget.restaurantName == "학생식당" &&
+                                  menu.length == 1)
+                                Padding(
+                                  padding: const EdgeInsets.only(bottom: 6),
+                                  child: Row(
+                                    mainAxisAlignment:
+                                        MainAxisAlignment.spaceBetween,
+                                    children: [
+                                      Text(
+                                        menu[0],
+                                        style: const TextStyle(
+                                          fontSize: 14,
+                                          fontWeight: FontWeight.w600,
+                                        ),
                                       ),
-                                    ),
-                                    Text(
-                                      widget.mealsForDay[index].price,
-                                      style: const TextStyle(
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.w600,
+                                      Text(
+                                        widget.mealsForDay[index].price,
+                                        style: const TextStyle(
+                                          fontSize: 14,
+                                          fontWeight: FontWeight.w600,
+                                        ),
+                                      ),
+                                    ],
+                                  ),
+                                )
+                              else
+                                Column(
+                                  crossAxisAlignment: CrossAxisAlignment.start,
+                                  children: [
+                                    if (widget.restaurantName != "카우버거")
+                                      Text(
+                                        widget.mealsForDay[index].price,
+                                        style: const TextStyle(
+                                          fontSize: 14,
+                                          fontWeight: FontWeight.w500,
+                                        ),
+                                      ),
+                                    Padding(
+                                      padding: const EdgeInsets.only(
+                                        top: 10,
+                                        // bottom: 10,
+                                      ),
+                                      child: GridView.builder(
+                                        physics:
+                                            const NeverScrollableScrollPhysics(),
+                                        shrinkWrap: true,
+                                        gridDelegate:
+                                            SliverGridDelegateWithFixedCrossAxisCount(
+                                          crossAxisCount: crossCount,
+                                          childAspectRatio: 5,
+                                        ),
+                                        itemCount: menu.length,
+                                        itemBuilder: (context, index) {
+                                          return SizedBox(
+                                            child: Text(
+                                              menu[index],
+                                              style: const TextStyle(
+                                                fontSize: 14,
+                                                fontWeight: FontWeight.w600,
+                                              ),
+                                              overflow: TextOverflow.ellipsis,
+                                            ),
+                                          );
+                                        },
                                       ),
                                     ),
                                   ],
-                                ),
-                              )
-                            else
-                              Column(
-                                crossAxisAlignment: CrossAxisAlignment.start,
-                                children: [
-                                  if (widget.restaurantName != "카우버거")
-                                    Text(
-                                      widget.mealsForDay[index].price,
-                                      style: const TextStyle(
-                                        fontSize: 14,
-                                        fontWeight: FontWeight.w500,
-                                      ),
-                                    ),
-                                  Padding(
-                                    padding: const EdgeInsets.only(
-                                      top: 10,
-                                      // bottom: 10,
-                                    ),
-                                    child: GridView.builder(
-                                      physics:
-                                          const NeverScrollableScrollPhysics(),
-                                      shrinkWrap: true,
-                                      gridDelegate:
-                                          SliverGridDelegateWithFixedCrossAxisCount(
-                                        crossAxisCount: crossCount,
-                                        childAspectRatio: 5,
-                                      ),
-                                      itemCount: menu.length,
-                                      itemBuilder: (context, index) {
-                                        return SizedBox(
-                                          child: Text(
-                                            menu[index],
-                                            style: const TextStyle(
-                                              fontSize: 14,
-                                              fontWeight: FontWeight.w600,
-                                            ),
-                                            overflow: TextOverflow.ellipsis,
-                                          ),
-                                        );
-                                      },
-                                    ),
-                                  ),
-                                ],
-                              )
-                          ],
-                        ),
-                      );
-                    },
+                                )
+                            ],
+                          ),
+                        );
+                      },
+                    ),
                   ),
-                ),
-              )
-          ],
+                )
+            ],
+          ),
         ),
       ),
     );

--- a/lib/widgets/menu_widget.dart
+++ b/lib/widgets/menu_widget.dart
@@ -248,6 +248,9 @@ class _MenuState extends State<Menu> {
         child: Padding(
           padding: const EdgeInsets.only(
             left: 20,
+            right: 10,
+            top: 10,
+            bottom: 10,
           ),
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
@@ -288,6 +291,7 @@ class _MenuState extends State<Menu> {
                   padding: const EdgeInsets.only(
                     right: 20,
                     bottom: 10,
+                    top: 10,
                   ),
                   child: MediaQuery.removePadding(
                     removeTop: true,


### PR DESCRIPTION
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
## 🟠 관련 이슈
- close #45 

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
## 🟠 구현/변경 사항 및 이유
기존 터치영역이 chevron 아이콘에만 주어져 사용이 불편하다는 유저 피드백을 받았습니다. 이를 개선하기 위하여 메뉴 전체로 터치 영역을 넓혀 보다 나은 사용자 경험을 제공합니다. 

기존 IconButton 으로 구현되었던 것을 단순 Icon 으로 변경하고 메뉴 위젯 전체를 GestureDetector 로 감싸주었습니다. 이 과정에서 기존 IconButton 이 가지고 있던 영역이 줄어들어 메뉴 상단 타이틀의 영역 또한 줄어들었습니다. 이를 해결하기 위하여 타이틀과 상세 메뉴 텍스트에 패딩값을 조정하였습니다. 

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
## 🟠 PR Point


<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
## 🟠 참고 사항

<img width="362" alt="Screenshot 2023-03-27 at 23 56 02" src="https://user-images.githubusercontent.com/64766255/227978783-c3cb89f6-38ee-4749-8466-ae6a4ae0c422.png">
