### PR TITLE
[FIX] setting screen 의 터치영역을 수정하였습니다.

### DIFF
--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -438,20 +438,21 @@ class _SettingScreenState extends State<SettingScreen> {
           const SizedBox(
             height: 16,
           ),
-          ListView.separated(
-            physics: const NeverScrollableScrollPhysics(),
-            shrinkWrap: true,
-            itemBuilder: (context, index) {
-              return GestureDetector(
-                onTap: () {
-                  if (index == 0 || index == 1) {
-                    luanchURL(index);
-                  } else {
-                    sendEmail();
-                  }
-                },
-                child: Container(
-                  color: Colors.white,
+          Container(
+            color: Colors.white,
+            child: ListView.separated(
+              physics: const NeverScrollableScrollPhysics(),
+              shrinkWrap: true,
+              itemBuilder: (context, index) {
+                return GestureDetector(
+                  onTap: () {
+                    if (index == 0 || index == 1) {
+                      luanchURL(index);
+                    } else {
+                      sendEmail();
+                    }
+                  },
+                  behavior: HitTestBehavior.opaque,
                   child: Padding(
                     padding: const EdgeInsets.only(
                       left: 20,
@@ -477,14 +478,14 @@ class _SettingScreenState extends State<SettingScreen> {
                       ],
                     ),
                   ),
-                ),
-              );
-            },
-            separatorBuilder: (context, index) => Container(
-              color: NyamColors.grey50.withOpacity(0.5),
-              child: const SizedBox(height: 1),
+                );
+              },
+              separatorBuilder: (context, index) => Container(
+                color: NyamColors.grey50.withOpacity(0.5),
+                child: const SizedBox(height: 1),
+              ),
+              itemCount: 3,
             ),
-            itemCount: 3,
           )
         ],
       ),

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -165,77 +165,77 @@ class _SettingScreenState extends State<SettingScreen> {
       ),
       body: Column(
         children: [
-          Container(
-            color: Colors.white,
-            child: Padding(
-              padding: const EdgeInsets.symmetric(
-                horizontal: 20,
-                vertical: 14,
-              ),
-              child: Row(
-                mainAxisAlignment: MainAxisAlignment.spaceBetween,
-                crossAxisAlignment: CrossAxisAlignment.center,
-                children: [
-                  const Text(
-                    "기본 캠퍼스 설정",
-                    style: TextStyle(
-                      fontSize: 16,
-                      fontWeight: FontWeight.w600,
+          GestureDetector(
+            onTap: () {
+              showCupertinoModalPopup(
+                context: context,
+                builder: (context) => CupertinoActionSheet(
+                  title: const Text("캠퍼스를 선택해주세요."),
+                  actions: <Widget>[
+                    CupertinoActionSheetAction(
+                      onPressed: () {
+                        setState(() {
+                          touchUpInsideToChangeFavoriteCampus('서울');
+                          Navigator.pop(context, 'Cancel');
+                          HomeScreen.isSelectedRestaurant = [
+                            true,
+                            false,
+                            false,
+                            false,
+                            false,
+                          ];
+                        });
+                      },
+                      child: const Text(
+                        "서울캠퍼스",
+                      ),
                     ),
-                  ),
-                  GestureDetector(
-                    onTap: () {
-                      showCupertinoModalPopup(
-                        context: context,
-                        builder: (context) => CupertinoActionSheet(
-                          title: const Text("캠퍼스를 선택해주세요."),
-                          actions: <Widget>[
-                            CupertinoActionSheetAction(
-                              onPressed: () {
-                                setState(() {
-                                  touchUpInsideToChangeFavoriteCampus('서울');
-                                  Navigator.pop(context, 'Cancel');
-                                  HomeScreen.isSelectedRestaurant = [
-                                    true,
-                                    false,
-                                    false,
-                                    false,
-                                    false,
-                                  ];
-                                });
-                              },
-                              child: const Text(
-                                "서울캠퍼스",
-                              ),
-                            ),
-                            CupertinoActionSheetAction(
-                              onPressed: () {
-                                setState(() {
-                                  touchUpInsideToChangeFavoriteCampus('안성');
-                                  Navigator.pop(context, 'Cancel');
-                                  HomeScreen.isSelectedRestaurant = [
-                                    true,
-                                    false,
-                                    false,
-                                  ];
-                                });
-                              },
-                              child: const Text(
-                                "안성캠퍼스",
-                              ),
-                            ),
-                          ],
-                          cancelButton: CupertinoActionSheetAction(
-                            isDefaultAction: true,
-                            onPressed: () {
-                              Navigator.pop(context, 'Cancel');
-                            },
-                            child: const Text("취소"),
-                          ),
-                        ),
-                      );
+                    CupertinoActionSheetAction(
+                      onPressed: () {
+                        setState(() {
+                          touchUpInsideToChangeFavoriteCampus('안성');
+                          Navigator.pop(context, 'Cancel');
+                          HomeScreen.isSelectedRestaurant = [
+                            true,
+                            false,
+                            false,
+                          ];
+                        });
+                      },
+                      child: const Text(
+                        "안성캠퍼스",
+                      ),
+                    ),
+                  ],
+                  cancelButton: CupertinoActionSheetAction(
+                    isDefaultAction: true,
+                    onPressed: () {
+                      Navigator.pop(context, 'Cancel');
                     },
-                    child: Row(
+                    child: const Text("취소"),
+                  ),
+                ),
+              );
+            },
+            child: Container(
+              color: Colors.white,
+              child: Padding(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: 20,
+                  vertical: 14,
+                ),
+                child: Row(
+                  mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                  crossAxisAlignment: CrossAxisAlignment.center,
+                  children: [
+                    const Text(
+                      "기본 캠퍼스 설정",
+                      style: TextStyle(
+                        fontSize: 16,
+                        fontWeight: FontWeight.w600,
+                      ),
+                    ),
+                    Row(
                       mainAxisAlignment: MainAxisAlignment.center,
                       crossAxisAlignment: CrossAxisAlignment.center,
                       children: [
@@ -257,9 +257,9 @@ class _SettingScreenState extends State<SettingScreen> {
                           ),
                         ),
                       ],
-                    ),
-                  )
-                ],
+                    )
+                  ],
+                ),
               ),
             ),
           ),

--- a/lib/screens/setting_screen.dart
+++ b/lib/screens/setting_screen.dart
@@ -438,20 +438,20 @@ class _SettingScreenState extends State<SettingScreen> {
           const SizedBox(
             height: 16,
           ),
-          Container(
-            color: Colors.white,
-            child: ListView.separated(
-              physics: const NeverScrollableScrollPhysics(),
-              shrinkWrap: true,
-              itemBuilder: (context, index) {
-                return GestureDetector(
-                  onTap: () {
-                    if (index == 0 || index == 1) {
-                      luanchURL(index);
-                    } else {
-                      sendEmail();
-                    }
-                  },
+          ListView.separated(
+            physics: const NeverScrollableScrollPhysics(),
+            shrinkWrap: true,
+            itemBuilder: (context, index) {
+              return GestureDetector(
+                onTap: () {
+                  if (index == 0 || index == 1) {
+                    luanchURL(index);
+                  } else {
+                    sendEmail();
+                  }
+                },
+                child: Container(
+                  color: Colors.white,
                   child: Padding(
                     padding: const EdgeInsets.only(
                       left: 20,
@@ -477,14 +477,14 @@ class _SettingScreenState extends State<SettingScreen> {
                       ],
                     ),
                   ),
-                );
-              },
-              separatorBuilder: (context, index) => Container(
-                color: NyamColors.grey50.withOpacity(0.5),
-                child: const SizedBox(height: 1),
-              ),
-              itemCount: 3,
+                ),
+              );
+            },
+            separatorBuilder: (context, index) => Container(
+              color: NyamColors.grey50.withOpacity(0.5),
+              child: const SizedBox(height: 1),
             ),
+            itemCount: 3,
           )
         ],
       ),


### PR DESCRIPTION
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
## 🟠 관련 이슈
- close #47 

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
## 🟠 구현/변경 사항 및 이유
설정 스크린에서 기본 캠퍼스를 선택하는 영역과 하단의 포털 연결 메뉴 영역의 터치 영역이 사용자 경험적으로 옳지 못한 것 같아 해당 로우 전체로 확장하였습니다. 이 과정에서 하단 포털 메뉴 영역의 경우 padding 값에 gesturedetector 를 감싸주었는데 여백 공간은 터치를 디텍트하지 못하는 문제가 발생하였습니다. 하지만 padding 을 container 로 한번 감싸준 뒤에 gesturedetector 를 감싸주니 문제가 해결되었습니다. 

++
https://velog.io/@sangh518/Flutter-GestureDetector
자료를 검색한 결과 해당 링크에서 다른 방법을 찾아내었습니다. gesturedectector 에 behavior 프로퍼티를 이용하여 해결할 수 있었습니다.

`behavior: HitTestBehavior.opaqub`

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
## 🟠 PR Point


<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
## 🟠 참고 사항

