### PR TITLE
[FIX] 설정 스크린에서 홈 스크린 진입시 레스토랑 피커 초기화

### DIFF
--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -185,6 +185,23 @@ class _HomeScreenState extends State<HomeScreen> {
         sevenDateTime[HomeScreen.isSelectedDate.indexOf(true)]);
   }
 
+  void resetRestaurantPicekr() {
+    HomeScreen.isSelectedRestaurant = HomeScreen.entryPoint == CampusType.seoul
+        ? [
+            true,
+            false,
+            false,
+            false,
+            false,
+          ]
+        : [
+            true,
+            false,
+            false,
+          ];
+    HomeScreen.pageController.jumpToPage(0);
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -304,6 +321,7 @@ class _HomeScreenState extends State<HomeScreen> {
                       );
                       setState(() {
                         getMealsByDate();
+                        resetRestaurantPicekr();
                         HomeScreen.pageController = PageController(
                             initialPage: 0, viewportFraction: 0.9);
                       });


### PR DESCRIPTION
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
## 🟠 관련 이슈
- close #51 

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
## 🟠 구현/변경 사항 및 이유
설정 스크린에서 홈 스크린 진입시에 식단을 새로 불러오게 되어 페이지 뷰가 리셋 되지만 레스토랑 피커가 초기화 되지 않는 버그를 수정하였습니다. 따라서 해당되는 피커의 bool 값을 초기화해주었고 jumpToPage 를 통해 맨 처음으로 이동하도록 구현하였습니다.

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
## 🟠 PR Point


<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
## 🟠 참고 사항


https://user-images.githubusercontent.com/64766255/227991796-c7c0987a-6747-434b-a5ce-5d06673a3cbb.mov

