### PR TITLE
[FEAT] 메뉴 순서를 변경하고 간격을 조정하였습니다.

### DIFF
--- a/lib/widgets/menu_widget.dart
+++ b/lib/widgets/menu_widget.dart
@@ -53,6 +53,21 @@ class _MenuState extends State<Menu> {
     setStatus();
     setIcon();
     setTitle();
+    sortStudentRestaurantMenu();
+  }
+
+  void sortStudentRestaurantMenu() {
+    if (widget.restaurantName == "학생식당") {
+      if (widget.mealsForDay.isNotEmpty) {
+        var setmenu = widget.mealsForDay
+            .where((element) => element.menu.length != 1)
+            .toList();
+        if (setmenu != []) {
+          widget.mealsForDay.last = widget.mealsForDay.first;
+          widget.mealsForDay.first = setmenu.first;
+        }
+      }
+    }
   }
 
   void checkIsBurgerOrRamen() {

--- a/lib/widgets/menu_widget.dart
+++ b/lib/widgets/menu_widget.dart
@@ -346,6 +346,18 @@ class _MenuState extends State<Menu> {
                                     ],
                                   ),
                                 )
+                              else if (widget.restaurantName == "카우버거")
+                                Column(
+                                  children: [
+                                    Text(
+                                      menu[index],
+                                      style: const TextStyle(
+                                        fontSize: 14,
+                                        fontWeight: FontWeight.w600,
+                                      ),
+                                    )
+                                  ],
+                                )
                               else
                                 Column(
                                   crossAxisAlignment: CrossAxisAlignment.start,
@@ -385,7 +397,7 @@ class _MenuState extends State<Menu> {
                                           );
                                         },
                                       ),
-                                    ),
+                                    )
                                   ],
                                 )
                             ],

--- a/lib/widgets/menu_widget.dart
+++ b/lib/widgets/menu_widget.dart
@@ -316,6 +316,7 @@ class _MenuState extends State<Menu> {
                         return Padding(
                           padding: const EdgeInsets.only(
                             top: 10,
+                            bottom: 5,
                           ),
                           child: Column(
                             crossAxisAlignment: CrossAxisAlignment.start,
@@ -360,7 +361,6 @@ class _MenuState extends State<Menu> {
                                     Padding(
                                       padding: const EdgeInsets.only(
                                         top: 10,
-                                        // bottom: 10,
                                       ),
                                       child: GridView.builder(
                                         physics:
@@ -369,7 +369,7 @@ class _MenuState extends State<Menu> {
                                         gridDelegate:
                                             SliverGridDelegateWithFixedCrossAxisCount(
                                           crossAxisCount: crossCount,
-                                          childAspectRatio: 5,
+                                          childAspectRatio: 4,
                                         ),
                                         itemCount: menu.length,
                                         itemBuilder: (context, index) {


### PR DESCRIPTION
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
## 🟠 관련 이슈
- close #53 
<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
## 🟠 구현/변경 사항 및 이유
작업된 디자인 대로 메뉴들의 간격을 조정하였습니다. 이 과정에서 안성 캠퍼스의 카우버거의 간격이 올바르지 못하게 적용되어 따로 분기처리를 통해 뷰를 그리도록 하였습니다.

서울 캠퍼스의 학생식당의 경우 단일메뉴와 세트메뉴가 동시에 제공되고 있기 때문에 세트메뉴를 상단에 위치하고 그 하단에 단일 메뉴들이 나오도록 하였습니다. 이것은 menu 위젯을 그릴때 전달되는 mealsForDay 를 sorting 하여 순서대로 그릴 수 있도록 하였습니다.

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
## 🟠 PR Point


<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
## 🟠 참고 사항

<img width="359" alt="image" src="https://user-images.githubusercontent.com/64766255/232283827-c482e522-e4d2-4ab0-950e-578fd676e160.png">
