### PR TITLE
[fix] 카우버거, 라면 운영시간 안내 변경 (#58)

### DIFF
--- a/lib/widgets/menu_widget.dart
+++ b/lib/widgets/menu_widget.dart
@@ -78,11 +78,18 @@ class _MenuState extends State<Menu> {
 
   void setOpenTime() {
     if (widget.mealsForDay.isNotEmpty) {
-      openTimeString =
-          widget.mealsForDay[0].openTime[0].toString().substring(11, 16);
-      closeTimeString =
-          widget.mealsForDay[0].openTime[1].toString().substring(11, 16);
-
+      if (widget.restaurantName == "카우버거") {
+        openTimeString = "09:30";
+        closeTimeString = "18:30";
+      } else if (widget.restaurantName == "라면") {
+        openTimeString = "06:00";
+        closeTimeString = "23:00";
+      } else {
+        openTimeString =
+            widget.mealsForDay[0].openTime[0].toString().substring(11, 16);
+        closeTimeString =
+            widget.mealsForDay[0].openTime[1].toString().substring(11, 16);
+      }
       openTimeint = int.parse(openTimeString.replaceAll(":", ""));
       closeTimeint = int.parse(closeTimeString.replaceAll(":", ""));
     }


### PR DESCRIPTION
<!-- 관련있는 이슈 번호(#000)을 적어주세요. -->
## 🟠 관련 이슈
- close #59 

<!-- 구현/변경한 내용과 그 이유를 적어주세요. -->
## 🟠 구현/변경 사항 및 이유
안성캠퍼스의 카우버거와 라면의 운영시간이 제대로 나오지 않는 버그를 수정하였습니다. 중앙대 측에서 올려주는 학식 정보의 시간이 제대로 기입되어 있지 않기 때문인 것으로 보입니다. 하지만 카우버거와 라면의 경우 운영시간이 고정적이기 때문에 고정값을 넣어주어 해결하였습니다.

<!-- 리뷰어 분들이 집중적으로 보셨으면 하는 내용을 적어주세요 -->
## 🟠 PR Point


<!-- 참고할 사항(+스크린샷)이 있다면 적어주세요. -->
## 🟠 참고 사항

